### PR TITLE
Display panel values as set in ini file on load. NAV1, NAV2 can display 4 digits. XPDR displays inHg and hPa under software control.

### DIFF
--- a/Xsaitekpanels/xsaitekpanels.ini
+++ b/Xsaitekpanels/xsaitekpanels.ini
@@ -3,32 +3,39 @@
 ;All lines beginning with a ; are comments
 ;
 ;William R Good
-;
-Version = 3.03
-;
+
+Version = 3.04
+
 ;File id tag allows the user to test if they have the correct xsaitekpanels.ini file | 0 = default | xx = integer of your choice
 ;The IDTag value is saved to the dataref bgood/xsaitekpanels/idtag  Wait .5 seconds and read this dataref to see if it matches
 IDTag = 0
-;
+
 ;This allows the Xsaitekpanels datareferences to be visible in Data Reference Editor
 ;http://www.xsquawkbox.net/xpsdk/mediawiki/DataRefEditorPlugin
 ;Data Reference Editor enable = 0 disable | = 1 enable
 Data Reference Editor enable = 0
 
-
 ;Display Plane ICAO On Screen Enable = 0 disable | = 1 enable
 Display Plane ICAO On Screen Enable = 0
-
 
 ;Add debug logging to Log.txt file Enable = 0 disable | = 1 enable | = 9 enable
 ; = 1 Enable Multipanel knob acceleration logging  = 9 Enable Switch Panel Gear Led logging
 Add Debug Entries To Log Enable = 0
 
+;Radio and multi panel status cannot be read until it recieves input. So these options set the values for your preferred startup switch positions until input is received.
+;Upper radio panel switch position for display on load = 1 com1 | = 2 com2 | = 3 nav1 | = 4 nav2 | = 5 adf1 | = 8 dme | = 9 xpdr/baro1 | = 10 blank display
+Upper Radio Switch = 1
+
+;Lower radio panel switch position for display on load = 1 com1 | = 2 com2 | = 3 nav1 | = 4 nav2 | = 5 adf2 | = 8 dme | = 9 xpdr/baro2 | = 10 blank display
+Lower Radio Switch = 2
+
+;Multi panel switch position for display on load = 1 Alt | = 1 Vs | = 2 Ias | = 3 Hdg | = 4 Crs | = 5 blank display
+Multi Switch = 1
+
 
 ;  *********** Switch Panel Mappings  ************
 ;Dissable switch panel in VR  = 0 false | = 1 true
 Dissable Switch Panel In VR = 0
-
 
 ;Bat Alt inverse = 0 Normal | = 1 Cessna
 Bat Alt inverse = 0
@@ -2614,13 +2621,13 @@ Metric Press enable = 0
 
 
 ;  ******** 8.33 KHz Channel Spacing for Com 1 & 2  ********
-; ** Can be disabeled which is the default or enabeled to use this feature **
+; ** Can be disabled which is the default or enabled to use this feature **
 ;Channel Spacing 883 enable = 0 disabled | = 1 enable
 Channel Spacing 883 enable = 0
 
 
 ;  ******** Dme Display Dist Left and Speed Right  ********
-; ** Can be disabeled which is the default or enabeled to use this feature **
+; ** Can be disabled which is the default or enabled to use this feature **
 ;Dme Display Dist Speed enable = 0 disabled | = 1 enable
 Dme Display Dist Speed enable = 0
 

--- a/src/multipanel.cpp
+++ b/src/multipanel.cpp
@@ -1788,7 +1788,7 @@ void process_ap_master_switch()
         }
         if (appushed == 1) {
             aploop++;
-            if (aploop == 50) {
+            if (aploop == 10) {
                appushed = 0;
                aploop = 0;
             }
@@ -1871,7 +1871,7 @@ void process_ap_master_switch()
 
             if (appushed == 1) {
                 aploop++;
-                if (aploop == 50) {
+                if (aploop == 10) {
                    appushed = 0;
                    aploop = 0;
                 }
@@ -1960,7 +1960,7 @@ void process_ap_master_switch()
 
         if (appushed == 1) {
             aploop++;
-            if (aploop == 50) {
+            if (aploop == 10) {
                appushed = 0;
                aploop = 0;
             }
@@ -2065,7 +2065,7 @@ void process_ap_master_switch()
 
         if (appushed == 1) {
             aploop++;
-            if (aploop == 50) {
+            if (aploop == 10) {
                 appushed = 0;
                 aploop = 0;
             }
@@ -4724,7 +4724,7 @@ void process_multi_panel(float dt)
     process_multi_display();
 
     // ******* Write on changes or timeout ********
-    if ((lastmultiseldis != multiseldis) || (lastbtnleds != btnleds) || (multinowrite > 50)) {
+    if ((lastmultiseldis != multiseldis) || (lastbtnleds != btnleds) || (multinowrite > 10)) {
         mulres = hid_send_feature_report(multihandle, multiwbuf, sizeof(multiwbuf));
         multinowrite = 1;
         lastmultiseldis = multiseldis;

--- a/src/multipanel.cpp
+++ b/src/multipanel.cpp
@@ -70,7 +70,7 @@ static int multiaactv, multiadig1, multiarem1, multiadig2, multiarem2;
 static int multiadig3, multiarem3, multiadig4, multiarem4, multiadig5;
 static int multibstby, multibdig1, multibdig2, multibrem2;
 static int multibdig3, multibrem3, multibdig4, multibrem4, multibdig5;  
-static int btnleds = 0, lastbtnleds = 0, multiseldis = 5;
+static int btnleds = 0, lastbtnleds = 0, multiseldis = 1;
 
 static int ALT_SWITCH = 7, VS_SWITCH = 6;
 static int IAS_SWITCH = 5, HDG_SWITCH = 4;
@@ -4693,6 +4693,25 @@ void process_multi_panel(float dt)
     do {
         multires = hid_read(multihandle, multibuf, sizeof(multibuf));
         process_multi_panel_datareference_values();
+        if (multibuf[0] == 0) {
+           multiseldis = multiswitchpos;
+           lastmultiseldis = multiseldis;
+           if (multiswitchpos == 1) {
+              upapaltf = XPLMGetDataf(ApAlt);
+              upapalt = (int)(upapaltf);
+              upapvsf = XPLMGetDataf(ApVs);
+              upapvs = (int)(upapvsf);
+           } else if (multiswitchpos == 2) {
+              apasf = XPLMGetDataf(ApAs);
+              apasout = (int)(apasf);
+           } else if (multiswitchpos == 3) {
+              upaphdgf = XPLMGetDataf(ApHdg);
+              upaphdg = (int)(upaphdgf);
+           } else if (multiswitchpos == 4) {
+              upapcrsf = XPLMGetDataf(ApCrs);
+              upapcrs = (int)(upapcrsf);
+           }
+        }
         process_alt_switch();
         process_vs_switch();
         process_ias_switch();

--- a/src/radio1data.cpp
+++ b/src/radio1data.cpp
@@ -20,6 +20,14 @@ void process_radio1_upper_datareference()
 {
 
 
+        MetricPressEnabledDataRef = XPLMRegisterDataAccessor("bgood/xsaitekpanels/radiopanel/metricpress/status",
+                                 xplmType_Int,
+                                 1,
+                                 MetricPressEnabledStatusGetDataiCallback,
+                                 MetricPressEnabledStatusSetDataiCallback,
+                                 NULL, NULL, NULL, NULL, NULL, NULL, NULL,
+                                 NULL, NULL, NULL, NULL, NULL);
+
         Rad1UpperCom1OwnedDataRef = XPLMRegisterDataAccessor("bgood/xsaitekpanels/radiopanel/rad1uprcom1/status",
                                  xplmType_Int,
                                  1,
@@ -492,6 +500,7 @@ void process_radio1_lower_datareference()
 
 void process_radio1_unregister_xsaitekpanels_datareference()
 {
+    XPLMUnregisterDataAccessor(MetricPressEnabledDataRef);
     XPLMUnregisterDataAccessor(Rad1UpperCom1OwnedDataRef);
     XPLMUnregisterDataAccessor(Rad1UpperCom2OwnedDataRef);
     XPLMUnregisterDataAccessor(Rad1UpperNav1OwnedDataRef);
@@ -608,6 +617,8 @@ void process_radio_find_xplane_commands()
 
       BaroUp = XPLMFindCommand("sim/instruments/barometer_up");
       BaroDn = XPLMFindCommand("sim/instruments/barometer_down");
+      BaroUp2 = XPLMFindCommand("sim/instruments/barometer_copilot_up");
+      BaroDn2 = XPLMFindCommand("sim/instruments/barometer_copilot_down");
       BaroStd = XPLMFindCommand("sim/instruments/barometer_2992");
 
       Com1ActStby = XPLMFindCommand("sim/radios/com1_standy_flip");
@@ -653,6 +664,7 @@ void process_radio_find_xplane_datareference()
       XpdrCode = XPLMFindDataRef("sim/cockpit/radios/transponder_code");
       XpdrMode = XPLMFindDataRef("sim/cockpit/radios/transponder_mode");
       BaroSetting = XPLMFindDataRef("sim/cockpit/misc/barometer_setting");
+      BaroSetting2 = XPLMFindDataRef("sim/cockpit/misc/barometer_setting2");
       MetricPress = XPLMFindDataRef("sim/physics/metric_press");
 
       DmeMode = XPLMFindDataRef("sim/cockpit2/radios/actuators/DME_mode");

--- a/src/radiopanels.cpp
+++ b/src/radiopanels.cpp
@@ -2302,7 +2302,7 @@ void process_upper_nav2_switch()
     }
 }
 
-// ***************** Upper AFD Switch Position *******************
+// ***************** Upper ADF Switch Position *******************
 
 void proecss_upper_adf_switch()
 {
@@ -8447,6 +8447,88 @@ void process_radio_panel()
     radiores = hid_read(radiohandle[radnum], radiobuf[radnum], sizeof(radiobuf[radnum]));
 
     process_upper_datareferences();
+    if (radiobuf[radnum][0] == 0) {
+       upseldis[radnum] = upradioswitchpos;
+       loseldis[radnum] = loradioswitchpos;
+       lastupseldis[radnum] = upseldis[radnum];
+       lastloseldis[radnum] = loseldis[radnum];
+       if (upseldis[radnum] == 1) {
+          if (channelspacing833enable == 0) {
+             upactcomfreq[radnum] = XPLMGetDatai(Com1ActFreq);
+             upactcomfreq[radnum] = upactcomfreq[radnum] * 10;
+             upstbycomfreq[radnum] = XPLMGetDatai(Com1StbyFreq);
+             upstbycomfreq[radnum] = upstbycomfreq[radnum] * 10;
+          } else if (channelspacing833enable == 1) {
+             upactcomfreq[radnum] = XPLMGetDatai(Com1ActFreq_833);
+             upstbycomfreq[radnum] = XPLMGetDatai(Com1StbyFreq_833);
+          }
+       } else if (upseldis[radnum] == 2) {
+          if (channelspacing833enable == 0) {
+             upactcomfreq[radnum] = XPLMGetDatai(Com2ActFreq);
+             upactcomfreq[radnum] = upactcomfreq[radnum] * 10;
+             upstbycomfreq[radnum] = XPLMGetDatai(Com2StbyFreq);
+             upstbycomfreq[radnum] = upstbycomfreq[radnum] * 10;
+          } else if (channelspacing833enable == 1) {
+             upactcomfreq[radnum] = XPLMGetDatai(Com2ActFreq_833);
+             upstbycomfreq[radnum] = XPLMGetDatai(Com2StbyFreq_833);
+          }
+       } else if (upseldis[radnum] == 3) {
+             upactnavfreq[radnum] = XPLMGetDatai(Nav1ActFreq);
+             upstbynavfreq[radnum] = XPLMGetDatai(Nav1StbyFreq);
+       } else if (upseldis[radnum] == 4) {
+             upactnavfreq[radnum] = XPLMGetDatai(Nav2ActFreq);
+             upstbynavfreq[radnum] = XPLMGetDatai(Nav2StbyFreq);
+       } else if (upseldis[radnum] == 5) {
+             upactadffreq[radnum] = XPLMGetDatai(Adf1ActFreq);
+             upstbyadffreq[radnum] = XPLMGetDatai(Adf1StbyFreq);
+       } else if (upseldis[radnum] == 8) {
+             updmenavspeed[radnum] = (int)(updmenav1speedf[radnum]);
+             updmetime[radnum] = XPLMGetDataf(DmeTime);
+       } else if (upseldis[radnum] == 9) {
+             float BaroValue1 = XPLMGetDataf(BaroSetting);
+             int BaroValue1i = round(BaroValue1 * 100.0);
+             upbaroset[radnum] = BaroValue1i;
+             upxpdrcode[radnum] = XPLMGetDatai(XpdrCode);
+       }
+       if (loseldis[radnum] == 1) {
+          if (channelspacing833enable == 0) {
+             loactcomfreq[radnum] = XPLMGetDatai(Com1ActFreq);
+             loactcomfreq[radnum] = loactcomfreq[radnum] * 10;
+             lostbycomfreq[radnum] = XPLMGetDatai(Com1StbyFreq);
+             lostbycomfreq[radnum] = lostbycomfreq[radnum] * 10;
+          } else if (channelspacing833enable == 1) {
+             loactcomfreq[radnum] = XPLMGetDatai(Com1ActFreq_833);
+             lostbycomfreq[radnum] = XPLMGetDatai(Com1StbyFreq_833);
+          }
+       } else if (loseldis[radnum] == 2) {
+          if (channelspacing833enable == 0) {
+             loactcomfreq[radnum] = XPLMGetDatai(Com2ActFreq);
+             loactcomfreq[radnum] = loactcomfreq[radnum] * 10;
+             lostbycomfreq[radnum] = XPLMGetDatai(Com2StbyFreq);
+             lostbycomfreq[radnum] = lostbycomfreq[radnum] * 10;
+          } else if (channelspacing833enable == 1) {
+             loactcomfreq[radnum] = XPLMGetDatai(Com2ActFreq_833);
+             lostbycomfreq[radnum] = XPLMGetDatai(Com2StbyFreq_833);
+          }
+       } else if (loseldis[radnum] == 3) {
+             loactnavfreq[radnum] = XPLMGetDatai(Nav1ActFreq);
+             lostbynavfreq[radnum] = XPLMGetDatai(Nav1StbyFreq);
+       } else if (loseldis[radnum] == 4) {
+             loactnavfreq[radnum] = XPLMGetDatai(Nav2ActFreq);
+             lostbynavfreq[radnum] = XPLMGetDatai(Nav2StbyFreq);
+       } else if (loseldis[radnum] == 5) {
+             loactadffreq[radnum] = XPLMGetDatai(Adf2ActFreq);
+             lostbyadffreq[radnum] = XPLMGetDatai(Adf2StbyFreq);
+       } else if (loseldis[radnum] == 8) {
+             lodmenavspeed[radnum] = (int)(lodmenav1speedf[radnum]);
+             lodmetime[radnum] = XPLMGetDataf(DmeTime);
+       } else if (loseldis[radnum] == 9) {
+             float BaroValue2 = XPLMGetDataf(BaroSetting2);
+             int BaroValue2i = round(BaroValue2 * 100.0);
+             lobaroset[radnum] = BaroValue2i;
+             loxpdrcode[radnum] = XPLMGetDatai(XpdrCode);
+       }
+    }
     process_upper_com1_switch();
     process_upper_com2_switch();
     process_upper_nav1_switch();

--- a/src/radiopanels.cpp
+++ b/src/radiopanels.cpp
@@ -13,6 +13,7 @@
 #include <sys/stat.h>
 #include <fcntl.h>
 #include <string.h>
+#include <cmath>
 
 #define testbit(x, y)  ( ( ((const char*)&(x))[(y)>>3] & 0x80 >> ((y)&0x07)) >> (7-((y)&0x07) ) )
 
@@ -3053,11 +3054,11 @@ void process_upper_xpdr_switch()
             upxpdrmode[radnum] = XPLMGetDatai(XpdrMode);
             upbarosetf[radnum] = XPLMGetDataf(BaroSetting);
             if (metricpressenable == 0) {
-                upbarosetf[radnum] = upbarosetf[radnum] * 100.0;
+                upbarosetf[radnum] = round(upbarosetf[radnum] * 100.0);
                 XPLMSetDatai(MetricPress, 0);
             }
             if (metricpressenable == 1) {
-                upbarosetf[radnum] = upbarosetf[radnum] * 33.8639;
+                upbarosetf[radnum] = upbarosetf[radnum] * 33.8637526;
                 XPLMSetDatai(MetricPress, 1);
             }
             upbaroset[radnum] = (int)upbarosetf[radnum];
@@ -3267,11 +3268,11 @@ void process_upper_xpdr_switch()
             upxpdrmode[radnum] = XPLMGetDatai(XpdrMode);
             upbarosetf[radnum] = XPLMGetDataf(BaroSetting);
             if (metricpressenable == 0) {
-                upbarosetf[radnum] = upbarosetf[radnum] * 100.0;
+                upbarosetf[radnum] = round(upbarosetf[radnum] * 100.0);
                 XPLMSetDatai(MetricPress, 0);
             }
             if (metricpressenable == 1) {
-                upbarosetf[radnum] = upbarosetf[radnum] * 33.8639;
+                upbarosetf[radnum] = upbarosetf[radnum] * 33.8637526;
                 XPLMSetDatai(MetricPress, 1);
             }
             upbaroset[radnum] = (int)upbarosetf[radnum];
@@ -3480,11 +3481,11 @@ void process_upper_xpdr_switch()
             upxpdrmode[radnum] = XPLMGetDatai(XpdrMode);
             upbarosetf[radnum] = XPLMGetDataf(BaroSetting);
             if (metricpressenable == 0) {
-                upbarosetf[radnum] = upbarosetf[radnum] * 100.0;
+                upbarosetf[radnum] = round(upbarosetf[radnum] * 100.0);
                 XPLMSetDatai(MetricPress, 0);
             }
             if (metricpressenable == 1) {
-                upbarosetf[radnum] = upbarosetf[radnum] * 33.8639;
+                upbarosetf[radnum] = upbarosetf[radnum] * 33.8637526;
                 XPLMSetDatai(MetricPress, 1);
             }
             upbaroset[radnum] = (int)upbarosetf[radnum];
@@ -3724,11 +3725,11 @@ void process_upper_xpdr_switch()
             upxpdrmode[radnum] = XPLMGetDatai(XpdrMode);
             upbarosetf[radnum] = XPLMGetDataf(Rad1UpperXpdrBaroRemapableData);
             if (metricpressenable == 0) {
-                upbarosetf[radnum] = upbarosetf[radnum] * 100.0;
+                upbarosetf[radnum] = round(upbarosetf[radnum] * 100.0);
                 XPLMSetDatai(MetricPress, 0);
             }
             if (metricpressenable == 1) {
-                upbarosetf[radnum] = upbarosetf[radnum] * 33.8639;
+                upbarosetf[radnum] = upbarosetf[radnum] * 33.8637526;
                 XPLMSetDatai(MetricPress, 1);
             }
             upbaroset[radnum] = (int)upbarosetf[radnum];
@@ -3968,11 +3969,11 @@ void process_upper_xpdr_switch()
             upxpdrmode[radnum] = XPLMGetDatai(XpdrMode);
             upbarosetf[radnum] = XPLMGetDataf(Rad2UpperXpdrBaroRemapableData);
             if (metricpressenable == 0) {
-                upbarosetf[radnum] = upbarosetf[radnum] * 100.0;
+                upbarosetf[radnum] = round(upbarosetf[radnum] * 100.0);
                 XPLMSetDatai(MetricPress, 0);
             }
             if (metricpressenable == 1) {
-                upbarosetf[radnum] = upbarosetf[radnum] * 33.8639;
+                upbarosetf[radnum] = upbarosetf[radnum] * 33.8637526;
                 XPLMSetDatai(MetricPress, 1);
             }
             upbaroset[radnum] = (int)upbarosetf[radnum];
@@ -4210,11 +4211,11 @@ void process_upper_xpdr_switch()
            upxpdrmode[radnum] = XPLMGetDatai(XpdrMode);
            upbarosetf[radnum] = XPLMGetDataf(Rad3UpperXpdrBaroRemapableData);
            if (metricpressenable == 0) {
-               upbarosetf[radnum] = upbarosetf[radnum] * 100.0;
+               upbarosetf[radnum] = round(upbarosetf[radnum] * 100.0);
                XPLMSetDatai(MetricPress, 0);
            }
            if (metricpressenable == 1) {
-               upbarosetf[radnum] = upbarosetf[radnum] * 33.8639;
+               upbarosetf[radnum] = upbarosetf[radnum] * 33.8637526;
                XPLMSetDatai(MetricPress, 1);
            }
            upbaroset[radnum] = (int)upbarosetf[radnum];
@@ -4461,12 +4462,12 @@ void process_upper_xpdr_switch()
             upxpdrmode[radnum] = XPLMGetDatai(XpdrMode);
             upbarosetf[radnum] = XPLMGetDataf(BaroSetting);
             if (metricpressenable == 0) {
-                upbarosetf[radnum] = upbarosetf[radnum] * 100.0;
+                upbarosetf[radnum] = round(upbarosetf[radnum] * 100.0);
                 XPLMSetDatai(MetricPress, 0);
             }
 
             if (metricpressenable == 1) {
-                upbarosetf[radnum] = upbarosetf[radnum] * 33.8639;
+                upbarosetf[radnum] = upbarosetf[radnum] * 33.8637526;
                 XPLMSetDatai(MetricPress, 1);
             }
             upbaroset[radnum] = (int)upbarosetf[radnum];
@@ -6656,13 +6657,13 @@ void process_lower_xpdr_switch()
 
            loxpdrcode[radnum] = XPLMGetDatai(XpdrCode);
            loxpdrmode[radnum] = XPLMGetDatai(XpdrMode);
-           lobarosetf[radnum] = XPLMGetDataf(BaroSetting);
+           lobarosetf[radnum] = XPLMGetDataf(BaroSetting2);
            if (metricpressenable == 0) {
-               lobarosetf[radnum] = lobarosetf[radnum] * 100.0;
+               lobarosetf[radnum] = round(lobarosetf[radnum] * 100.0);
                XPLMSetDatai(MetricPress, 0);
            }
            if (metricpressenable == 1) {
-               lobarosetf[radnum] = lobarosetf[radnum] * 33.8639;
+               lobarosetf[radnum] = lobarosetf[radnum] * 33.8637526;
                XPLMSetDatai(MetricPress, 1);
            }
            lobaroset[radnum] = (int)lobarosetf[radnum];
@@ -6875,13 +6876,13 @@ void process_lower_xpdr_switch()
 
            loxpdrcode[radnum] = XPLMGetDatai(XpdrCode);
            loxpdrmode[radnum] = XPLMGetDatai(XpdrMode);
-           lobarosetf[radnum] = XPLMGetDataf(BaroSetting);
+           lobarosetf[radnum] = XPLMGetDataf(BaroSetting2);
            if (metricpressenable == 0) {
-               lobarosetf[radnum] = lobarosetf[radnum] * 100.0;
+               lobarosetf[radnum] = round(lobarosetf[radnum] * 100.0);
                XPLMSetDatai(MetricPress, 0);
            }
            if (metricpressenable == 1) {
-               lobarosetf[radnum] = lobarosetf[radnum] * 33.8639;
+               lobarosetf[radnum] = lobarosetf[radnum] * 33.8637526;
                XPLMSetDatai(MetricPress, 1);
            }
            lobaroset[radnum] = (int)lobarosetf[radnum];
@@ -7089,13 +7090,13 @@ void process_lower_xpdr_switch()
 
             loxpdrcode[radnum] = XPLMGetDatai(XpdrCode);
             loxpdrmode[radnum] = XPLMGetDatai(XpdrMode);
-            lobarosetf[radnum] = XPLMGetDataf(BaroSetting);
+            lobarosetf[radnum] = XPLMGetDataf(BaroSetting2);
             if (metricpressenable == 0) {
-                lobarosetf[radnum] = lobarosetf[radnum] * 100.0;
+                lobarosetf[radnum] = round(lobarosetf[radnum] * 100.0);
                 XPLMSetDatai(MetricPress, 0);
             }
             if (metricpressenable == 1) {
-                lobarosetf[radnum] = lobarosetf[radnum] * 33.8639;
+                lobarosetf[radnum] = lobarosetf[radnum] * 33.8637526;
                 XPLMSetDatai(MetricPress, 1);
             }
             lobaroset[radnum] = (int)lobarosetf[radnum];
@@ -7331,11 +7332,11 @@ void process_lower_xpdr_switch()
             loxpdrmode[radnum] = XPLMGetDatai(XpdrMode);
             lobarosetf[radnum] = XPLMGetDataf(Rad1LowerXpdrBaroRemapableData);
             if (metricpressenable == 0) {
-                lobarosetf[radnum] = lobarosetf[radnum] * 100.0;
+                lobarosetf[radnum] = round(lobarosetf[radnum] * 100.0);
                 XPLMSetDatai(MetricPress, 0);
             }
             if (metricpressenable == 1) {
-                lobarosetf[radnum] = lobarosetf[radnum] * 33.8639;
+                lobarosetf[radnum] = lobarosetf[radnum] * 33.8637526;
                 XPLMSetDatai(MetricPress, 1);
             }
             lobaroset[radnum] = (int)lobarosetf[radnum];
@@ -7570,11 +7571,11 @@ void process_lower_xpdr_switch()
             loxpdrmode[radnum] = XPLMGetDatai(XpdrMode);
             lobarosetf[radnum] = XPLMGetDataf(Rad2LowerXpdrBaroRemapableData);
             if (metricpressenable == 0) {
-                lobarosetf[radnum] = lobarosetf[radnum] * 100.0;
+                lobarosetf[radnum] = round(lobarosetf[radnum] * 100.0);
                 XPLMSetDatai(MetricPress, 0);
             }
             if (metricpressenable == 1) {
-                lobarosetf[radnum] = lobarosetf[radnum] * 33.8639;
+                lobarosetf[radnum] = lobarosetf[radnum] * 33.8637526;
                 XPLMSetDatai(MetricPress, 1);
             }
             lobaroset[radnum] = (int)lobarosetf[radnum];
@@ -7808,11 +7809,11 @@ void process_lower_xpdr_switch()
             loxpdrmode[radnum] = XPLMGetDatai(XpdrMode);
             lobarosetf[radnum] = XPLMGetDataf(Rad3LowerXpdrBaroRemapableData);
             if (metricpressenable == 0) {
-                lobarosetf[radnum] = lobarosetf[radnum] * 100.0;
+                lobarosetf[radnum] = round(lobarosetf[radnum] * 100.0);
                 XPLMSetDatai(MetricPress, 0);
             }
             if (metricpressenable == 1) {
-                lobarosetf[radnum] = lobarosetf[radnum] * 33.8639;
+                lobarosetf[radnum] = lobarosetf[radnum] * 33.8637526;
                 XPLMSetDatai(MetricPress, 1);
             }
             lobaroset[radnum] = (int)lobarosetf[radnum];
@@ -8011,7 +8012,7 @@ void process_lower_xpdr_switch()
                 if ((Last_Lower_Fine_Up[radnum] == 1) && (testbit(radiobuf[radnum],LOWER_FINE_UP) == 0)) {
                     loqnhdbncfninc[radnum]++;
                     if (loqnhdbncfninc[radnum] > radspeed) {
-                        XPLMCommandOnce(BaroUp);
+                        XPLMCommandOnce(BaroUp2);
                         loqnhdbncfninc[radnum] = 0;
                     }
                 }
@@ -8020,7 +8021,7 @@ void process_lower_xpdr_switch()
                 if ((Last_Lower_Fine_Dn[radnum] == 1) && (testbit(radiobuf[radnum],LOWER_FINE_DN) == 0)) {
                     loqnhdbncfndec[radnum]++;
                     if (loqnhdbncfndec[radnum] > radspeed) {
-                        XPLMCommandOnce(BaroDn);
+                        XPLMCommandOnce(BaroDn2);
                         loqnhdbncfndec[radnum] = 0;
                     }
                 }
@@ -8032,7 +8033,7 @@ void process_lower_xpdr_switch()
                     if (loqnhdbnccorinc[radnum] > radspeed) {
                         radn = 10;
                         while (radn>0) {
-                            XPLMCommandOnce(BaroUp);
+                            XPLMCommandOnce(BaroUp2);
                             --radn;
                         }
                         loqnhdbnccorinc[radnum] = 0;
@@ -8046,7 +8047,7 @@ void process_lower_xpdr_switch()
                     if (loqnhdbnccordec[radnum] > radspeed) {
                         radn = 10;
                         while (radn>0) {
-                            XPLMCommandOnce(BaroDn);
+                            XPLMCommandOnce(BaroDn2);
                             --radn;
                         }
                         loqnhdbnccordec[radnum] = 0;
@@ -8061,14 +8062,14 @@ void process_lower_xpdr_switch()
 
             loxpdrcode[radnum] = XPLMGetDatai(XpdrCode);
             loxpdrmode[radnum] = XPLMGetDatai(XpdrMode);
-            lobarosetf[radnum] = XPLMGetDataf(BaroSetting);
+            lobarosetf[radnum] = XPLMGetDataf(BaroSetting2);
             if (metricpressenable == 0) {
-                lobarosetf[radnum] = lobarosetf[radnum] * 100.0;
+                lobarosetf[radnum] = round(lobarosetf[radnum] * 100.0);
                 XPLMSetDatai(MetricPress, 0);
             }
 
             if (metricpressenable == 1) {
-                lobarosetf[radnum] = lobarosetf[radnum] * 33.8639;
+                lobarosetf[radnum] = lobarosetf[radnum] * 33.8637526;
                 XPLMSetDatai(MetricPress, 1);
             }
             lobaroset[radnum] = (int)lobarosetf[radnum];
@@ -8222,11 +8223,26 @@ void process_upper_nav_freq()
           //UpNav2ObsDegm[radnum] = XPLMGetDataf(Nav2ObsDegm);
           radiobstby = (int)(UpNav2ObsDegm[radnum]);
       }
-      radiobdig1 = 15, radiobdig2 = 15;
+      radiobdig1 = 15;
       //radiobstby = radiobstby + 10;
-      radiobdig3 = radiobstby/100, radiobrem3 = radiobstby%100;
-      radiobdig4 = radiobrem3/10, radiobrem4 = radiobrem3%10;
-      radiobdig3 = radiobdig3, radiobdig5 = radiobrem4;
+      if (radiobstby > 999) {
+      	radiobdig2 = radiobstby/1000, radiobrem2 = radiobstby%1000;
+        radiobdig3 = radiobrem2/100, radiobrem3 = radiobrem2%100;
+        radiobdig4 = radiobrem3/10, radiobrem4 = radiobrem3%10;
+        radiobdig3 = radiobdig3, radiobdig5 = radiobrem4;
+				float BaroValue1 = XPLMGetDataf(BaroSetting);
+				float BaroValue2 = XPLMGetDataf(BaroSetting2);
+        int BaroValue1i = round(BaroValue1 * 100.0);
+        int BaroValue2i = round(BaroValue2 * 100.0);
+          if (metricpressenable == 0 && (BaroValue1i == radiodstby || BaroValue2i == radiodstby)) {
+              radiobdig3 = radiobdig3+208;
+          }
+   		} else if (radiobstby < 1000) {
+        radiobdig2 = 15;
+        radiobdig3 = radiobstby/100, radiobrem3 = radiobstby%100;
+        radiobdig4 = radiobrem3/10, radiobrem4 = radiobrem3%10;
+        radiobdig3 = radiobdig3, radiobdig5 = radiobrem4;
+      }
   }
 
 
@@ -8312,12 +8328,27 @@ void process_lower_nav_freq()
           radiodstby = (int)(LoNav2ObsDegm[radnum]);
       }
 
-      radioddig1 = 15, radioddig2 = 15;
+      radioddig1 = 15;
       //radiodstby = radiodstby + 10;
 
-      radioddig3 = radiodstby/100, radiodrem3 = radiodstby%100;
-      radioddig4 = radiodrem3/10, radiodrem4 = radiodrem3%10;
-      radioddig3 = radioddig3, radioddig5 = radiodrem4;
+      if (radiodstby > 999) {
+      	radioddig2 = radiodstby/1000, radiodrem2 = radiodstby%1000;
+        radioddig3 = radiodrem2/100, radiodrem3 = radiodrem2%100;
+        radioddig4 = radiodrem3/10, radiodrem4 = radiodrem3%10;
+        radioddig3 = radioddig3, radioddig5 = radiodrem4;
+				float BaroValue1 = XPLMGetDataf(BaroSetting);
+				float BaroValue2 = XPLMGetDataf(BaroSetting2);
+        int BaroValue1i = round(BaroValue1 * 100.0);
+        int BaroValue2i = round(BaroValue2 * 100.0);
+          if (metricpressenable == 0 && (BaroValue1i == radiodstby || BaroValue2i == radiodstby)) {
+              radioddig3 = radioddig3+208;
+          }
+   		} else if (radiodstby < 1000) {
+        radioddig2 = 15;
+        radioddig3 = radiodstby/100, radiodrem3 = radiodstby%100;
+        radioddig4 = radiodrem3/10, radiodrem4 = radiodrem3%10;
+        radioddig3 = radioddig3, radioddig5 = radiodrem4;
+      }
   }
 
   return;
@@ -8476,6 +8507,7 @@ void process_radio_panel()
         radionowrite[radnum] = 1;
         lastupseldis[radnum] = upseldis[radnum];
         lastloseldis[radnum] = loseldis[radnum];
+        metricpressenable = XPLMGetDatai(MetricPressEnabledDataRef);
     }else{
         radionowrite[radnum]++;
     }

--- a/src/radiopanels.cpp
+++ b/src/radiopanels.cpp
@@ -8584,7 +8584,7 @@ void process_radio_panel()
 
 // ******* Write on changes or timeout *******
 
-    if ((lastupseldis[radnum] != upseldis[radnum]) || (lastloseldis[radnum] != loseldis[radnum]) || (radionowrite[radnum] > 50) || (xpanelsfnbutton == 1)) {
+    if ((lastupseldis[radnum] != upseldis[radnum]) || (lastloseldis[radnum] != loseldis[radnum]) || (radionowrite[radnum] > 10) || (xpanelsfnbutton == 1)) {
         radres = hid_send_feature_report(radiohandle[radnum], radiowbuf[radnum], sizeof(radiowbuf[radnum]));
         radionowrite[radnum] = 1;
         lastupseldis[radnum] = upseldis[radnum];

--- a/src/readinifile.cpp
+++ b/src/readinifile.cpp
@@ -93,6 +93,9 @@ void process_read_ini_file()
     landinglightswitchenable = 1;
     gearledenable = 1;
 
+    upradioswitchpos = 1;
+    loradioswitchpos = 2;
+    multiswitchpos = 1;
     bataltinverse = 0;
     starterswitchenable = 0;
 
@@ -320,6 +323,15 @@ void process_read_ini_file()
 
     sprintf(buf, "Xsaitekpanels: dre_enable = %d  icao_enable = %d  log_enable = %d dissableSwitchPanelInVR = %d dissableRadioPanelInVR = %d dissableMultiPanelInVR = %d\n", dre_enable, icao_enable, log_enable, dissableSwitchPanelInVR, dissableRadioPanelInVR, dissableMultiPanelInVR);
     XPLMDebugString(buf);
+
+    // Default upper radio panel switch position
+    readOptionAsInt("Upper Radio Switch", &upradioswitchpos, true);
+
+    // Default lower radio panel switch position
+    readOptionAsInt("Lower Radio Switch", &loradioswitchpos, true);
+
+    // Default multi panel switch position
+    readOptionAsInt("Multi Switch", &multiswitchpos, true);
 
     // bat alt normal alt bat cessna
     readOptionAsInt("Bat Alt inverse", &bataltinverse, true);

--- a/src/readinifile.cpp
+++ b/src/readinifile.cpp
@@ -2154,6 +2154,11 @@ void process_read_ini_file()
     readOptionAsInt("Metric Press enable", &metricpressenable, true);
     readOptionAsInt("Channel Spacing 883 enable", &channelspacing833enable);
 
+    if (metricpressenable == 0) {
+    XPLMSetDatai(MetricPressEnabledDataRef, 0);
+    } else if (metricpressenable == 1) {
+    XPLMSetDatai(MetricPressEnabledDataRef, 1);
+    }
     sprintf(radtestbuf1, "Xsaitekpanels: channelspacing833enable ==  %d \n", channelspacing833enable);
     XPLMDebugString(radtestbuf1);
 

--- a/src/saitekpanels.cpp
+++ b/src/saitekpanels.cpp
@@ -2406,6 +2406,8 @@ int beaconlightswitchenable, navlightswitchenable;
 int strobelightswitchenable, taxilightswitchenable;
 int landinglightswitchenable, bataltinverse;
 int panellightsenable, starterswitchenable;
+int upradioswitchpos, loradioswitchpos;
+int multiswitchpos;
 
 int gearledenable;
 int gearled_write_loop = 0;

--- a/src/saitekpanels.cpp
+++ b/src/saitekpanels.cpp
@@ -2,8 +2,8 @@
 // ****  William R. Good   ***********
 // ****** Jan 29  2023   **************
 
-#define PLUGIN_VERSION "3.03 stable build " __DATE__ " " __TIME__
-#define PLUGIN_VERSION_NUMBER 303
+#define PLUGIN_VERSION "3.04 stable build " __DATE__ " " __TIME__
+#define PLUGIN_VERSION_NUMBER 304
 
 #include "XPLMDisplay.h"
 #include "XPLMGraphics.h"
@@ -1113,6 +1113,8 @@ static unsigned char blankradiowbuf[4][23];
 static unsigned char radiobuf[4][4], radiowbuf[4][23];
 
 unsigned char radbuf[4], radwbuf[21];
+
+static int PluginVersion, radiovdig3, radiovrem3, radiovdig4, radiovrem4, radiovdig5;
 
 int radspeed, numadf, metricpressenable, channelspacing833enable;
 int dmedistspeedenable;
@@ -3333,6 +3335,11 @@ PLUGIN_API int XPluginStart(char *		outName,
 
 // ************* Open any Radio that is connected *****************
 
+  PluginVersion = XsaitekpanelsVersion;
+  radiovdig3 = PluginVersion/100, radiovrem3 = PluginVersion%100;
+  radiovdig4 = radiovrem3/10, radiovrem4 = radiovrem3%10;
+  radiovdig5 = radiovrem4;
+
   struct hid_device_info *rad_devs, *rad_cur_dev;
 
   rad_devs = hid_enumerate(0x6a3, 0x0d05);
@@ -3342,7 +3349,25 @@ PLUGIN_API int XPluginStart(char *		outName,
         hid_set_nonblocking(radiohandle[radcnt], 1);
         radiores = hid_read(radiohandle[radcnt], radiobuf[radcnt], sizeof(radiobuf[radcnt]));
         radiowbuf[0][1] = 1, radiowbuf[1][1] = 2, radiowbuf[2][1] = 3;
+        radiowbuf[0][2] = 15+224, radiowbuf[1][2] = 15+224, radiowbuf[2][2] = 15+224;
+        radiowbuf[0][3] = 1, radiowbuf[1][3] = 1, radiowbuf[2][3] = 1;
+        radiowbuf[0][4] = 15, radiowbuf[1][4] = 15, radiowbuf[2][4] = 15;
+        radiowbuf[0][5] = 15, radiowbuf[1][5] = 15, radiowbuf[2][5] = 15;
+        radiowbuf[0][6] = 15, radiowbuf[1][6] = 15, radiowbuf[2][6] = 15;
+        radiowbuf[0][7] = 15, radiowbuf[1][7] = 15, radiowbuf[2][7] = 15;
+        radiowbuf[0][8] = radiovdig3+208, radiowbuf[1][8] = radiovdig3+208, radiowbuf[2][8] = radiovdig3+208;
+        radiowbuf[0][9] = radiovdig4, radiowbuf[1][9] = radiovdig4, radiowbuf[2][9] = radiovdig4;
+        radiowbuf[0][10] = radiovdig5, radiowbuf[1][10] = radiovdig5, radiowbuf[2][10] = radiovdig5;
         radiowbuf[0][11] = 1, radiowbuf[1][11] = 2, radiowbuf[2][11] = 3;
+        radiowbuf[0][12] = 15+224, radiowbuf[1][12] = 15+224, radiowbuf[2][12] = 15+224;
+        radiowbuf[0][13] = 2, radiowbuf[1][13] = 2, radiowbuf[2][13] = 2;
+        radiowbuf[0][14] = 15, radiowbuf[1][14] = 15, radiowbuf[2][14] = 15;
+        radiowbuf[0][15] = 15, radiowbuf[1][15] = 15, radiowbuf[2][15] = 15;
+        radiowbuf[0][16] = 15, radiowbuf[1][16] = 15, radiowbuf[2][16] = 15;
+        radiowbuf[0][17] = 15, radiowbuf[1][17] = 15, radiowbuf[2][17] = 15;
+        radiowbuf[0][18] = radiovdig3+208, radiowbuf[1][18] = radiovdig3+208, radiowbuf[2][18] = radiovdig3+208;
+        radiowbuf[0][19] = radiovdig4, radiowbuf[1][19] = radiovdig4, radiowbuf[2][19] = radiovdig4;
+        radiowbuf[0][20] = radiovdig5, radiowbuf[1][20] = radiovdig5, radiowbuf[2][20] = radiovdig5;
         hid_send_feature_report(radiohandle[radcnt], radiowbuf[radcnt], 23);
         radcnt++;
         rad_cur_dev = rad_cur_dev->next;
@@ -3359,6 +3384,10 @@ PLUGIN_API int XPluginStart(char *		outName,
         multihandle = hid_open_path(multi_cur_dev->path);
         hid_set_nonblocking(multihandle, 1);
         multires = hid_read(multihandle, multibuf, sizeof(multibuf));
+        multiwbuf[0] = 0, multiwbuf[1] = 15, multiwbuf[2] = 15;
+        multiwbuf[3] = 0, multiwbuf[4] = 0, multiwbuf[5] = 0;
+        multiwbuf[6] = 15, multiwbuf[7] = 15, multiwbuf[8] = 15;
+        multiwbuf[9] = 0, multiwbuf[10] = 0, multiwbuf[11] = 0;
         hid_send_feature_report(multihandle, multiwbuf, 13);
         multicnt++;
         multi_cur_dev = multi_cur_dev->next;

--- a/src/saitekpanels.cpp
+++ b/src/saitekpanels.cpp
@@ -62,7 +62,7 @@ XPLMCommandRef	Afd2StbyOnesUp = NULL, Afd2StbyOnesDn = NULL;
 
 XPLMCommandRef	XpdrThUp = NULL, XpdrThDn = NULL, XpdrHunUp = NULL, XpdrHunDn = NULL;
 XPLMCommandRef	XpdrTensUp = NULL, XpdrTensDn = NULL, XpdrOnesUp = NULL, XpdrOnesDn = NULL;
-XPLMCommandRef	BaroUp = NULL, BaroDn = NULL, BaroStd = NULL;
+XPLMCommandRef	BaroUp = NULL, BaroDn = NULL, BaroUp2 = NULL, BaroDn2 = NULL, BaroStd = NULL;
 
 
 XPLMCommandRef Com1ActStby = NULL, Com2ActStby = NULL, Nav1ActStby = NULL, Nav2ActStby = NULL;
@@ -230,8 +230,9 @@ XPLMDataRef Com1StbyFreq_833 = NULL, Com2StbyFreq_833 = NULL;
 XPLMDataRef Adf1StbyFreq = NULL, Adf2StbyFreq = NULL;
 XPLMDataRef Adf1ActFreq = NULL, Adf2ActFreq = NULL;
 
-XPLMDataRef XpdrCode = NULL, XpdrMode = NULL, BaroSetting = NULL;
+XPLMDataRef XpdrCode = NULL, XpdrMode = NULL, BaroSetting = NULL, BaroSetting2 = NULL;
 XPLMDataRef MetricPress = NULL;
+XPLMDataRef MetricPressEnabledDataRef = NULL;
 
 XPLMDataRef DmeMode = NULL, DmeSlvSource = NULL;
 XPLMDataRef Nav1DmeNmDist = NULL, Nav1DmeSpeed = NULL;
@@ -1255,6 +1256,7 @@ int radioMenuItem;
 
 
 static int RadioPanelCountData = 0;
+static int MetricPressEnabledData = 0;
 static int Rad1UprCom1OwnedData = 0, Rad1UprCom2OwnedData = 0;
 static int Rad1UprNav1OwnedData = 0, Rad1UprNav2OwnedData = 0;
 static int Rad1UprAdfOwnedData = 0, Rad1UprDmeOwnedData = 0;
@@ -1373,6 +1375,8 @@ int Rad3LwrDigit9OwnedData = 0, Rad3LwrDigit10OwnedData = 0;
 int	RadioPanelCountGetDataiCallback(void * inRefcon);
 void	RadioPanelCountSetDataiCallback(void * inRefcon, int RadioPanelCount);
 
+int	MetricPressEnabledStatusGetDataiCallback(void * inRefcon);
+void	MetricPressEnabledStatusSetDataiCallback(void * inRefcon, int MetricPressEnabledStatus);
 
 int	Rad1UprCom1StatusGetDataiCallback(void * inRefcon);
 void	Rad1UprCom1StatusSetDataiCallback(void * inRefcon, int Rad1UprCom1Status);
@@ -5065,6 +5069,17 @@ void	RadioPanelCountSetDataiCallback(void * inRefcon, int RadioPanelCountData2)
     RadioPanelCountData = RadioPanelCountData2;
 }
 
+int	MetricPressEnabledStatusGetDataiCallback(void * inRefcon)
+{
+    (void) inRefcon;
+    return MetricPressEnabledData;
+}
+
+void	MetricPressEnabledStatusSetDataiCallback(void * inRefcon, int MetricPressEnabledStatus2)
+{
+    (void) inRefcon;
+    MetricPressEnabledData = MetricPressEnabledStatus2;
+}
 
 int	Rad1UprCom1StatusGetDataiCallback(void * inRefcon)
 {
@@ -8623,11 +8638,13 @@ int	RadioHandler(XPWidgetMessage  RadioinMessage, XPWidgetID  RadioWidgetID, int
             State = XPGetWidgetProperty(RadioQnh0CheckWidget[0], xpProperty_ButtonState, 0);
             if (State){
                 metricpressenable = 0;
+                XPLMSetDatai(MetricPressEnabledDataRef, 0);
             }
 
             State = XPGetWidgetProperty(RadioQnh1CheckWidget[0], xpProperty_ButtonState, 0);
             if (State){
                 metricpressenable = 1;
+                XPLMSetDatai(MetricPressEnabledDataRef, 1);
             }
          }
 
@@ -9276,6 +9293,7 @@ float XsaitekpanelsCustomDatarefLoopCB(float elapsedMe, float elapsedSim, int co
 
 
     XPLMSendMessageToPlugin(XPLM_NO_PLUGIN_ID, 0x01000000, (void*)"bgood/xsaitekpanels/radiopanel/count");
+    XPLMSendMessageToPlugin(XPLM_NO_PLUGIN_ID, 0x01000000, (void*)"bgood/xsaitekpanels/radiopanel/metricpress/status");
 
     if (radcnt > 0) {
         XPLMSendMessageToPlugin(XPLM_NO_PLUGIN_ID, 0x01000000, (void*)"bgood/xsaitekpanels/radiopanel/rad1uprcom1/status");

--- a/src/saitekpanels.h
+++ b/src/saitekpanels.h
@@ -34,7 +34,7 @@ extern XPLMCommandRef Afd2StbyOnesUp, Afd2StbyOnesDn;
 
 extern XPLMCommandRef XpdrThUp, XpdrThDn, XpdrHunUp, XpdrHunDn;
 extern XPLMCommandRef XpdrTensUp, XpdrTensDn, XpdrOnesUp, XpdrOnesDn;
-extern XPLMCommandRef BaroUp, BaroDn, BaroStd;
+extern XPLMCommandRef BaroUp, BaroDn, BaroUp2, BaroDn2, BaroStd;
 
 extern XPLMCommandRef Com1ActStby, Com2ActStby, Nav1ActStby, Nav2ActStby;
 extern XPLMCommandRef Adf1ActStby, Adf2ActStby;
@@ -202,8 +202,9 @@ extern XPLMDataRef Com1StbyFreq_833, Com2StbyFreq_833;
 extern XPLMDataRef Adf1StbyFreq, Adf2StbyFreq;
 extern XPLMDataRef Adf1ActFreq, Adf2ActFreq;
 
-extern XPLMDataRef XpdrCode, XpdrMode, BaroSetting;
+extern XPLMDataRef XpdrCode, XpdrMode, BaroSetting, BaroSetting2;
 extern XPLMDataRef MetricPress;
+extern XPLMDataRef MetricPressEnabledDataRef;
 extern XPLMDataRef DmeMode, DmeSlvSource;
 extern XPLMDataRef Nav1DmeNmDist, Nav1DmeSpeed;
 extern XPLMDataRef Nav2DmeNmDist, Nav2DmeSpeed;
@@ -577,6 +578,9 @@ extern float rad3_lwr_adf_actstby_btn_dataf_on_value, rad3_lwr_adf_actstby_btn_d
 extern float rad3_lwr_dme_actstby_btn_dataf_on_value, rad3_lwr_dme_actstby_btn_dataf_off_value;
 
 void UpdateUI(); 
+
+extern int	MetricPressEnabledStatusGetDataiCallback(void * inRefcon);
+extern void	MetricPressEnabledStatusSetDataiCallback(void * inRefcon, int MetricPressEnabledStatus);
 
 extern int	Rad1UprCom1StatusGetDataiCallback(void * inRefcon);
 extern void	Rad1UprCom1StatusSetDataiCallback(void * inRefcon, int Rad1UprCom1Status);

--- a/src/saitekpanels.h
+++ b/src/saitekpanels.h
@@ -2177,7 +2177,8 @@ extern int cowlflapsenable, panellightswitchenable;
 extern int beaconlightswitchenable, navlightswitchenable;
 extern int strobelightswitchenable, taxilightswitchenable;
 extern int landinglightswitchenable, bataltinverse;
-extern int starterswitchenable;
+extern int upradioswitchpos, loradioswitchpos;
+extern int multiswitchpos, starterswitchenable;
 
 extern int gearledenable;
 extern int gearled_write_loop;


### PR DESCRIPTION
XPDR can be changed from inHg and hPa by writing a DataRef, Lower Rado Panel defaults to copilot, Autopilot button keybounce shortened, Multi Panel update time reduced to 1/5 of current time, NAV1 and NAV2 with FN button goes to four digits when values are greater than 999, and automatic period added if an inHg Baro value. Radio panel and multi panel will display correct values as per chosen option in the ini file until input is given rather than blank displays.